### PR TITLE
Add build.os configuration key to .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,6 +3,9 @@
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+
 sphinx:
   configuration: doc/source/conf.py
 


### PR DESCRIPTION
https://blog.readthedocs.com/use-build-os-config/