### PR TITLE
Fix catastrophic cancellation in van_genuchten near the residual water content

### DIFF
--- a/src/fronts/D.py
+++ b/src/fronts/D.py
@@ -7,6 +7,7 @@ from typing import Literal, Protocol, overload
 
 import numpy as np
 import sympy  # type: ignore[import-untyped]
+from numpy import exp, expm1, log1p
 
 
 class _D0(Protocol):
@@ -123,6 +124,20 @@ class _VectorizedD2(Protocol):
     def __call__(
         self, theta: float, derivatives: Literal[2]
     ) -> tuple[float, float, float]: ...
+
+    @overload
+    def __call__(
+        self,
+        theta: np.ndarray[tuple[int, ...], np.dtype[np.floating]],
+        derivatives: Literal[2],
+    ) -> (
+        tuple[float, float, float]
+        | tuple[
+            np.ndarray[tuple[int, ...], np.dtype[np.floating]],
+            np.ndarray[tuple[int, ...], np.dtype[np.floating]],
+            np.ndarray[tuple[int, ...], np.dtype[np.floating]],
+        ]
+    ): ...
 
 
 def constant(D0: float) -> _VectorizedD2:
@@ -880,58 +895,58 @@ def van_genuchten(
     # Source: ../symbolic/van_genuchten.py
     x1 = 1 / (theta_range[0] - theta_range[1])
     x3 = 1 / m
-    x8 = l - x3
 
     def D(theta, derivatives=0):  # type: ignore[no-untyped-def]
         x0 = theta - theta_range[0]
         x2 = -x0 * x1
         x4 = x2**x3
-        x5 = (1 - x4) ** m
-        x6 = x5 - 2
-        x7 = (x5 * x6 + 1) / x5
-        x9 = Ks * x1 * x2**x8 * x3 * (m - 1) / alpha
-        D = x7 * x9
+        x5 = m * log1p(-x4)
+        x6 = expm1(x5)
+        x7 = x6**2
+        x8 = exp(-x5)
+        x9 = x8 / x4
+        x10 = x3 * x9
+        x11 = x10 * x7
+        x12 = Ks * x1 * x2**l * (m - 1) / alpha
+        D = x11 * x12
         if derivatives == 0:
             return D
-        x10 = (x1 * (-theta + theta_range[0])) ** x3
-        x11 = (1 - x10) ** m
-        x12 = x4 / (x10 - 1)
-        x13 = (x11 * (x11 - 2) + 1) / x11
-        dD_dtheta = x9 * (-x12 * x13 + 2 * x12 * (x11 - 1) + x13 * x8) / x0
+        x13 = x4 - 1
+        x14 = 1 / x13
+        x15 = 2 * x14
+        x16 = l * x6
+        x17 = x14 * x8
+        x18 = x12 * x3
+        dD_dtheta = x18 * x6 * (-x10 * x6 + x15 + x16 * x9 - x17 * x6) / x0
         if derivatives == 1:
             return D, dD_dtheta
-        x14 = x4 - 1
-        x15 = x2 ** (2 * x3) / x14**2
-        x16 = 4 * x5 - 4
-        x17 = x4 / x14
-        x18 = x7 * x8
-        x19 = x17 * x7
-        x20 = x15 * x7
-        x21 = x3 * x5
-        x22 = x3 * x6
+        x19 = x15 * x6
+        x20 = x4 / x13**2
+        x21 = 2 * x20
+        x22 = x21 * x6
+        x23 = x17 * x7
+        x24 = x7 * x9
+        x25 = x7 * x8
+        x26 = x20 * x25
         d2D_dtheta2 = (
-            x9
+            x18
             * (
-                -x15 * x16
-                + x16 * x17 * x8
-                - 2 * x17 * x18
-                + x17
-                * (
-                    -x17 * x21
-                    - x17 * x22
-                    + 3 * x17 * x5
-                    + x17 * x6
-                    + x21
-                    + x22
-                    - 2 * x5
-                    + 2
-                )
-                - x18
+                l**2 * x24
+                - 2 * l * x11
+                - l * x15 * x25
+                - l * x24
+                + x11
+                + 4 * x14 * x16
                 - x19 * x3
-                + x19
-                + x20 * x3
-                + x20
-                + x7 * x8**2
+                - x19
+                + x21 * exp(x5)
+                - x22 * x3
+                - x22
+                + x23 * x3
+                + x23
+                + x26 * x3
+                + x26
+                + x24 / m**2
             )
             / x0**2
         )
@@ -1425,20 +1440,20 @@ def richards(
         if derivatives == 0:
             return Ks * kr(theta) / C(theta)
 
-        K_ = [Ks * kr for kr in kr(theta, derivatives)]  # type: ignore[arg-type]
-        C_ = C(theta, derivatives)  # type: ignore[arg-type]
+        K_ = [Ks * kr for kr in kr(theta, derivatives)]
+        C_ = C(theta, derivatives)
 
         D = K_[0] / C_[0]
 
         dD_dtheta = (K_[1] * C_[0] - K_[0] * C_[1]) / C_[0] ** 2
 
         if derivatives == 1:
-            return D, dD_dtheta
+            return D, dD_dtheta  # type: ignore[return-value]
 
         d2D_dtheta2 = (K_[2] - 2 * dD_dtheta * C_[1] - D * C_[2]) / C_[0]  # type: ignore[misc]
 
         if derivatives == 2:
-            return D, dD_dtheta, d2D_dtheta2
+            return D, dD_dtheta, d2D_dtheta2  # type: ignore[return-value]
 
         msg = "derivatives must be 0, 1, or 2"
         raise ValueError(msg)

--- a/symbolic/generate.py
+++ b/symbolic/generate.py
@@ -25,8 +25,8 @@ def functionstr(var: sympy.Symbol | str, expr: sympy.Expr | str | float) -> str:
     expr : `sympy.Expr` or str or float
         SymPy-compatible expression. Any free symbols other than `var` will be
         taken as parameters that must be in scope when the returned code is
-        executed. Use of special functions and constructs is not currently
-        allowed.
+        executed. Mathematical functions (e.g. ``exp``, ``expm1``, ``log1p``)
+        are printed by name and must likewise be in scope.
 
     Returns
     -------
@@ -69,12 +69,11 @@ def functionstr(var: sympy.Symbol | str, expr: sympy.Expr | str | float) -> str:
     ]
 
     for n, (name, expr) in enumerate(zip(deriv_names, exprs, strict=True)):
-        for x in xs:
-            lines.extend(
-                "    {} = {}".format(*x)
-                for x in xs
-                if x[0] in variable and appearance[x] == n
-            )
+        lines.extend(
+            "    {} = {}".format(*x)
+            for x in xs
+            if x[0] in variable and appearance[x] == n
+        )
         lines.append(f"    {name} = {expr}")
         lines.append(
             f"    if derivatives == {n}: return {', '.join(deriv_names[: n + 1])}"

--- a/symbolic/van_genuchten.py
+++ b/symbolic/van_genuchten.py
@@ -8,6 +8,7 @@ Used only in development. Running this script requires SymPy.
 """
 
 import sympy  # type: ignore [import-untyped]
+from sympy.codegen.cfunctions import expm1, log1p  # type: ignore [import-untyped]
 
 from .generate import functionstr
 
@@ -19,20 +20,33 @@ theta = sympy.Symbol("theta", real=True)
 ################################
 Se = sympy.Symbol("Se", real=True, positive=True)
 
+# The bracketed term of Van Genuchten (1980) Equation 11,
+#
+#   (1 - Se**(1/m))**(-m) + (1 - Se**(1/m))**m - 2,
+#
+# is algebraically equal to w**(-1)*(w - 1)**2 with w = (1 - Se**(1/m))**m, but
+# evaluating it directly in floating point suffers catastrophic cancellation as
+# Se**(1/m) -> 0 (i.e., near the residual water content), where w - 1 -> 0. In
+# that regime the direct evaluation underflows to exact zero -- e.g., with
+# n=1.1, already at Se <= 0.1 -- which makes D() return 0 and breaks solvers
+# that divide by D. Writing w - 1 = expm1(m*log1p(-Se**(1/m))) evaluates the
+# bracket to full precision all the way down to the underflow limit of
+# Se**(1/m) itself.
+u = m * log1p(-(Se ** (1 / m)))
+
 D = (
     (1 - m)
     * Ks
     / (alpha * m * (theta_range[1] - theta_range[0]))
     * Se**l
     * Se ** (-1 / m)
-    * ((1 - Se ** (1 / m)) ** (-m) + (1 - Se ** (1 / m)) ** m - 2)
+    * expm1(u) ** 2
+    * sympy.exp(-u)
 )
 
 D = D.subs(Se, (theta - theta_range[0]) / (theta_range[1] - theta_range[0]))
 # Reference: Van Genuchten (1980) Equation 11
 # https://doi.org/10.2136/sssaj1980.03615995004400050002x
 ################################
-
-D = D.simplify()
 
 print(functionstr(theta, D))

--- a/tests/test_D.py
+++ b/tests/test_D.py
@@ -1,4 +1,5 @@
 # noqa: N999
+import numpy as np
 import pytest
 
 import fronts.D
@@ -34,3 +35,85 @@ def test_letd() -> None:
     assert D(0.15, 2) == pytest.approx(
         [0.05762335000343946, 1.3113046321882815, 4.376714990066025]
     )
+
+
+def test_brooks_and_corey() -> None:
+    D = fronts.D.brooks_and_corey(
+        n=2.0, l=1.0, alpha=1.7, Ks=1.8, theta_range=(0.1, 0.9)
+    )
+
+    assert D(0.5, 2) == pytest.approx(
+        [0.11698457776983322, 0.73115361106145766, 2.7418260414804663]
+    )
+    assert D(0.15, 2) == pytest.approx(
+        [0.00064625459558823492, 0.032312729779411753, 0.96938189338235281]
+    )
+
+
+def test_van_genuchten() -> None:
+    D = fronts.D.van_genuchten(n=1.1, alpha=1.7, Ks=1.8, theta_range=(0.1, 0.9))
+
+    # Reference values computed with mpmath at 500 significant digits
+    assert D(0.5, 2) == pytest.approx(
+        [3.7784647708968713e-05, 0.0010868161907242002, 0.028557488277842383]
+    )
+    # theta close to the residual water content: here the terms of the
+    # bracketed expression in the Van Genuchten diffusivity cancel almost
+    # completely, so a direct evaluation returns garbage (and eventually
+    # exactly 0, which breaks solvers that divide by D)
+    assert D(0.15, 2) == pytest.approx(
+        [1.5544201803211751e-15, 3.5751664147388968e-13, 7.5078494709525571e-11],
+        rel=1e-10,
+        abs=0.0,
+    )
+
+
+def test_van_genuchten_near_residual() -> None:
+    # Reference values computed with mpmath at 500 significant digits
+    cases = {
+        (1.1, 0.1): (
+            2.6134526117355634e-13,
+            3.0054705035246448e-11,
+            3.1557440287655587e-9,
+        ),
+        (1.1, 1e-3): (
+            2.613452611709472e-36,
+            3.0054705034658917e-32,
+            3.1557440286391852e-28,
+        ),
+        (1.5, 1e-4): (
+            2.2222222222244518e-15,
+            7.7777777777922467e-11,
+            1.9444444444523947e-6,
+        ),
+        (3.0, 1e-6): (
+            2.2222222244444491e-13,
+            4.4444444522222314e-7,
+            0.44444444638888976,
+        ),
+    }
+
+    for (n, theta), expected in cases.items():
+        D = fronts.D.van_genuchten(n=n)
+        assert D(theta, 2) == pytest.approx(expected, rel=1e-10, abs=0.0)
+
+    # vectorized evaluation must match the scalar path
+    D = fronts.D.van_genuchten(n=1.1)
+    theta_v: np.ndarray[tuple[int, ...], np.dtype[np.floating]] = np.array([0.1, 1e-3])
+    for k, values in enumerate(D(theta_v, 2)):
+        assert values == pytest.approx(
+            [cases[1.1, 0.1][k], cases[1.1, 1e-3][k]], rel=1e-14, abs=0.0
+        )
+
+
+def test_van_genuchten_no_underflow_near_residual() -> None:
+    theta: np.ndarray[tuple[int, ...], np.dtype[np.floating]] = np.logspace(
+        -12, -1, 100
+    )
+
+    for n in (1.1, 1.5, 2.0, 3.0, 5.0, 10.0):
+        D = fronts.D.van_genuchten(n=n)
+        d0, d1, d2 = D(theta, 2)
+        assert np.all(d0 > 0), f"n={n}: min D0 = {np.min(d0)}"
+        assert np.all(np.isfinite(d1)), f"n={n}"
+        assert np.all(np.isfinite(d2)), f"n={n}"

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -180,3 +180,22 @@ def test_scipy_17066() -> None:
     )
     fronts.solve(D=D, i=0.025, b=0.7 - 1e-7)
     fronts.solve(D=D, i=0.025, b=0.7 - 1e-7, method="explicit")
+
+
+def test_van_genuchten_near_residual() -> None:
+    # A Van Genuchten diffusivity evaluated close to the residual water
+    # content used to underflow to exactly 0, making these calls fail with
+    # ZeroDivisionError/ValueError
+    D = fronts.D.van_genuchten(n=1.1)
+
+    fun, jac = fronts.ode(D)
+    assert np.all(np.isfinite(fun(1.0, (0.1, -1.0))))
+    assert np.all(np.isfinite(jac(1.0, (0.1, -1.0))))
+
+    theta = fronts.solve(D=D, i=0.1, b=0.3)
+
+    o = np.linspace(0, 2, 100)
+    assert np.all(theta(o=o) >= theta.i)
+    assert np.all(theta(o=o) <= theta.b)
+    assert np.all(np.diff(theta(o=o)) <= 0)
+    assert theta(o=0) == pytest.approx(0.3, abs=1e-3)


### PR DESCRIPTION
`D.van_genuchten` evaluates the bracketed term of the Van Genuchten (1980) eq. 11 diffusivity,

```
(1 - Se^(1/m))^(-m) + (1 - Se^(1/m))^m - 2
```

directly in float64. As `Se^(1/m)` gets small — i.e. near the residual water content, which is ordinary territory for infiltration into dry media — all three terms are within rounding error of each other and the difference loses every significant digit, eventually underflowing to exactly 0. With `n=1.1` that already happens at `theta = 0.1`:

```python
>>> import fronts
>>> D = fronts.D.van_genuchten(n=1.1)
>>> D(0.1)
0.0
```

and everything downstream that divides by `D` fails:

```python
>>> fronts.solve(D=D, i=0.1, b=0.3)
ValueError: D(0.101, 1) returned invalid value
>>> fun, jac = fronts.ode(D)
>>> fun(1.0, (0.1, -1.0))
ZeroDivisionError: float division by zero
```

The derivatives go wrong even earlier: at `n=1.5, theta=0.001` the returned `D` is 0, `dD/dtheta` is 1.7x off, and `d2D/dtheta2` is ~11 orders of magnitude off. The exact-zero threshold by `n` (default `theta_range`, `l=0.5`): n=1.1 at θ≤0.1, n=1.5 at θ≤1e-3, n=2 at θ≤1e-5, n=3 at θ≤1e-6.

## Fix

The bracket equals `(w - 1)^2 / w` with `w = (1 - Se^(1/m))^m`, so the only difference that needs care is `w - 1`, which `expm1`/`log1p` evaluate to full precision:

```
u = m*log1p(-Se^(1/m));  bracket = expm1(u)^2 * exp(-u)
```

This is algebraically identical to the paper's expression. Writing the denominator as `exp(-u)` rather than `expm1(u) + 1` matters: the latter would trade the dry-end cancellation for a new one at the wet end.

The change is made in `symbolic/van_genuchten.py` (using `sympy.codegen.cfunctions.expm1`/`log1p`, which differentiate and print correctly) and `src/fronts/D.py` is regenerated with the repo's own `functionstr` workflow. The `D.simplify()` step is dropped: it folds `Se**l * Se**(-1/m)` back into a single `Se**(l - 1/m)` power, and that factor alone overflows near the residual (for scalar input it raises `OverflowError: Result too large`, which is how the old code fails for small `n` before it can even return garbage) — the split form produced without it degrades gracefully instead. While regenerating I found `functionstr` currently emits every local assignment `len(xs)` times — the outer `for x in xs:` loop in the dedup pass survived the refactor in e6a0ab5 that moved the condition into a generator expression. The first commit fixes that, restoring output that matches the checked-in style.

## Validation

Checked against the closed form and its exact symbolic derivatives evaluated with mpmath at 1200 significant digits, over `n ∈ {1.03..10} × l ∈ {0..2} × theta ∈ [1e-12, 1-1e-12]` (672 grid points whose true values are representable in float64):

| | before | after |
|---|---|---|
| points returning literal `D == 0.0` | 248 | 0 |
| max rel. error of D, D', D'' for θ ≤ 0.999 | up to 1.3e13 | 4.3e-13 |
| max rel. error at θ = 1 - 1e-12 | 2.5e-5 / 6.2e-5 / 9.9e-5 | identical |

No grid point got worse. The near-saturation figures are unchanged and to the last digit equal to the old code's: that error comes from representing `1 - Se^(1/m)` itself in float64 when θ is within ~1e-12 of saturation, which no rewrite of the bracket can influence. At the dry end, full accuracy now extends down to `Se^(1/m)` around 1e-154 (below that, squaring `expm1(u)` underflows and D degrades to 0 as before — that's θ - θr below ppm scale even at n=1.03).

## Tests

- direct unit tests for `van_genuchten` and `brooks_and_corey` (neither had any; `van_genuchten` was only reached through one solver test at parameters that never enter the cancellation regime), pinned against mpmath references,
- a near-residual regression matrix and an underflow sweep across `n`,
- a solver-level test: `fronts.solve` with `n=1.1` through the previously fatal regime, plus finiteness of `fronts.ode`'s `fun`/`jac` at the crash point above.

The array-input tests needed the `(ndarray, derivatives=2)` overload that was missing from the `_VectorizedD2` protocol, so that overload is added as well.

The other bundled models were audited for the same pattern: `brooks_and_corey`, `power_law`, `letxs` and `letd` are pure power/rational forms with no cancelling difference (finite-difference cross-checks show only normal rounding noise), and `richards` is an exact combinator of caller-supplied functions.
